### PR TITLE
Revert "base-files: add console to inittab"

### DIFF
--- a/target/linux/x86/base-files/etc/inittab
+++ b/target/linux/x86/base-files/etc/inittab
@@ -3,4 +3,3 @@
 ttyS0::askfirst:/usr/libexec/login.sh
 hvc0::askfirst:/usr/libexec/login.sh
 tty1::askfirst:/usr/libexec/login.sh
-console::askfirst:/usr/libexec/login.sh


### PR DESCRIPTION
This reverts commit cde52cb4866fe8cf4a19bb2bb32ff7802e542e19.
When using OpenWrt in qemu, the shell is unsuable

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
